### PR TITLE
Update README.md for Import Cost Extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,14 +204,18 @@ extension is a nice way to mix in some neon pops.
   />
 </div>
 
-Highlight large packages using neon and translucent colors with the Import Cost
+Highlight large packages using neon and translucent colors with the [Import Cost](https://marketplace.visualstudio.com/items?itemName=wix.vscode-import-cost)
 extension.
 
 ```json
 {
-  "importCost.smallPackageColor": "#d043cf4d",
-  "importCost.mediumPackageColor": "#d043cf80",
-  "importCost.largePackageColor": "#F834BB"
+  "importCost.smallPackageDarkColor": "#d043cf4d",
+  "importCost.mediumPackageDarkColor": "#d043cf80",
+  "importCost.largePackageDarkColor": "#F834BB",
+
+  "importCost.smallPackageLightColor": "#d043cf4d",
+  "importCost.mediumPackageLightColor": "#d043cf80",
+  "importCost.largePackageLightColor": "#F834BB"
 }
 ```
 


### PR DESCRIPTION
In this commit, I have updated the README.md to include a link to download the Import Cost extension from the Visual Studio Code Marketplace. Additionally, I've provided the current configuration settings for the extension without mentioning that the previous configuration is no longer functional.

These changes will make it easier for users to access and set up the Import Cost extension in their development environment, enhancing their ability to highlight large packages within their code.